### PR TITLE
add Trott as participant, convert unordered list to table

### DIFF
--- a/wontfix_cabal/participants.md
+++ b/wontfix_cabal/participants.md
@@ -3,29 +3,28 @@
 Every participant can add themselves before or at the beginning of the event by
 sending a pull request!
 
-- Jess Frazelle (organizer, [@jessfraz on GitHub](https://github.com/jessfraz), [@jessfraz on Twitter](https://twitter.com/jessfraz))
-- Katrina Owen (organizer, [@kytrinyx on GitHub](https://github.com/kytrinyx),
-  [@kytrinyx on Twitter](https://twitter.com/kytrinyx))
-- James Kyle (idiot, [@thejameskyle on GitHub](https://github.com/thejameskyle), [@thejameskyle on Twitter](https://twitter.com/thejameskyle))
-- Gregor Martynus (participant, [@gr2m on GitHub](https://github.com/gr2m/), [@gr2m on Twitter](https://twitter.com/gr2m/). LA based, 
-🛫 Wed, Feb 15 with [jetBlue 1136](https://www.google.com/search?q=jetBlue+1136) 🛬 Thu, Feb 16: [jetBlue 1435](https://www.google.com/search?q=jetBlue+1435)
-- Daniel McDonald (participant, [@wasade on GitHub](https://github.com/wasade), [@mcdonadt on Twitter](https://twitter.com/mcdonadt), SEA based, flights TBD
-- Daniel Bachhuber (participant, [@danielbachhuber on GitHub](https://github.com/danielbachhuber), [@danielbachhuber on Twitter](https://twitter.com/danielbachhuber), PDX based, arriving Weds morning on [Alaska 2589](https://www.google.com/search?q=Alaska+2589)
-- Sebastiaan van Stijn (participant, [@thaJeztah on GitHub](https://github.com/thaJeztah), [@thaJeztah on Twitter](https://twitter.com/thaJeztah), Located in The Netherlands 🇳🇱)
-- Tianon Gravi (bashochist, [@tianon on GitHub](https://github.com/tianon), [@tianon on Twitter](https://twitter.com/tianon))
-- Joe Ferguson (participant, [@yosifkit on GitHub](https://github.com/yosifkit), [@yosifkit on Twitter](https://twitter.com/yosifkit))
-- Luis Villa (participant, [@tieguy](https://github.com/tieguy) on Github, [lu.is](http://lu.is) on ye olde WWW, [@luis_in_140](http://twitter.com/luis_in_140) on Twitter, SF-based)
-- Matt Hooker (participant, @mwhooker on [Github](https://github.com/mwhooker) and [twitter](https://twitter.com/mwhooker)).
-- Emma Humphries (participant, [@emceeaich](https://github.com/emceeaich) on Github and [@triagegirl](https://twitter.com/triagegirl) on Twitter, Bay Area Local)
-- Brandon Keepers (host/participant, [@bkeepers on GitHub](https://github.com/bkeepers), [@bkeepers on Twitter](https://twitter.com/bkeepers)
-- Caleb Hailey (participant, [@calebhailey on GitHub](https://github.com/calebhailey), [@calebhailey on Twitter](https://twitter.com/calebhailey)
-- John Wiebalk (participant, [@jwiebalk on GitHub](https://github.com/jwiebalk), [@johnwiebalk on Twitter](https://twitter.com/johnwiebalk)
-- Kostya Serebryany (participant, [@kcc](https://github.com/kcc) @ GitHub, [@kayseesee](https://twitter.com/kayseesee) @ Twitter)
-- Lee Dohm (host/participant, [@lee-dohm](https://github.com/lee-dohm) on GitHub, [@leedohm](https://twitter.com/leedohm) on Twitter)
-- Eric Steele (participant, [@esteele on Github](https://github.com/esteele), [@esteele on Twitter](https://twitter.com/esteele))
-- James Turnbull (participant/general gadfly [@jamtur01 on GitHub](https://github.com/jamtur01), [@kartar on Twitter](https://twitter.com/kartar). NYC-based. 2/13 UA212 - 2/17 UA 212.
-- Tim Smith (participant, [@tas50 on GitHub](https://github.com/tas50), [@tas50 on Twitter](https://twitter.com/tas50), PDX based
-- Brian Doll (participant, [@briandoll on GitHub](https://github.com/briandoll), [@briandoll on Twitter](https://twitter.com/briandoll), SF
-- Jaana Burcu Dogan (participant, [@rakyll on GitHub](https://github.com/rakyll), [@rakyll on Twitter](https://twitter.com/rakyll))
-- Rich Trott (participant, [@Trott on GitHub](https://github.com/Trott), [@Trott on Twitter](https://twitter.com/Trott))
-
+| Name  | Role | GitHub | Twitter | Notes |
+| ----- | ---- | ------ | ------- | ----- |
+| Jess Frazelle  | organizer  | [@jessfraz](https://github.com/jessfraz) | [@jessfraz](https://twitter.com/jessfraz) | |
+| Katrina Owen | organizer | [@kytrinyx](https://github.com/kytrinyx) | [@kytrinyx](https://twitter.com/kytrinyx) | |
+| James Kyle | idiot | [@thejameskyle](https://github.com/thejameskyle) | [@thejameskyle](https://twitter.com/thejameskyle) | |
+| Gregor Martynus | participant |[@gr2m](https://github.com/gr2m/) | [@gr2m](https://twitter.com/gr2m/) | LA based 🛫 Wed, Feb 15 with [jetBlue 1136](https://www.google.com/search?q=jetBlue+1136) 🛬 Thu, Feb 16: [jetBlue 1435](https://www.google.com/search?q=jetBlue+1435) |
+| Daniel McDonald | participant |[@wasade](https://github.com/wasade) | [@mcdonadt](https://twitter.com/mcdonadt) | SEA based, flights TBD
+| Daniel Bachhuber | participant |[@danielbachhuber](https://github.com/danielbachhuber) | [@danielbachhuber](https://twitter.com/danielbachhuber) | PDX based, arriving Weds morning on [Alaska 2589](https://www.google.com/search?q=Alaska+2589)
+| Sebastiaan van Stijn | participant |[@thaJeztah](https://github.com/thaJeztah) | [@thaJeztah](https://twitter.com/thaJeztah) | Located in The Netherlands 🇳🇱
+| Tianon Gravi | bashochist | [@tianon](https://github.com/tianon) | [@tianon](https://twitter.com/tianon) | |
+| Joe Ferguson | participant |[@yosifkit](https://github.com/yosifkit) | [@yosifkit](https://twitter.com/yosifkit) | |
+| Luis Villa | participant |[@tieguy](https://github.com/tieguy) | [@luis_in_140](http://twitter.com/luis_in_140) |[lu.is](http://lu.is) on ye olde WWW, SF-based |
+| Matt Hooker | participant | [@mwhooker](https://github.com/mwhooker) | [@mwhooker](https://twitter.com/mwhooker) | |
+| Emma Humphries | participant |[@emceeaich](https://github.com/emceeaich) | [@triagegirl](https://twitter.com/triagegirl) | Bay Area Local |
+| Brandon Keepers | host/participant |[@bkeepers](https://github.com/bkeepers) | [@bkeepers](https://twitter.com/bkeepers) | |
+| Caleb Hailey | participant |[@calebhailey](https://github.com/calebhailey) | [@calebhailey](https://twitter.com/calebhailey) | |
+| John Wiebalk | participant |[@jwiebalk](https://github.com/jwiebalk) | [@johnwiebalk](https://twitter.com/johnwiebalk) | |
+| Kostya Serebryany | participant |[@kcc](https://github.com/kcc) | [@kayseesee](https://twitter.com/kayseesee) | |
+| Lee Dohm | host/participant |[@lee-dohm](https://github.com/lee-dohm) | [@leedohm](https://twitter.com/leedohm) | |
+| Eric Steele | participant |[@esteele](https://github.com/esteele) | [@esteele](https://twitter.com/esteele) | |
+| James Turnbull | participant/general gadfly | [@jamtur01](https://github.com/jamtur01) | [@kartar](https://twitter.com/kartar) | NYC-based. 2/13 UA212, 2/17 UA 212 |
+| Tim Smith | participant |[@tas50](https://github.com/tas50) | [@tas50](https://twitter.com/tas50) | PDX based |
+| Brian Doll | participant |[@briandoll](https://github.com/briandoll) | [@briandoll](https://twitter.com/briandoll) | SF |
+| Jaana Burcu Dogan | participant |[@rakyll](https://github.com/rakyll) | [@rakyll](https://twitter.com/rakyll) | |
+| Rich Trott | participant |[@Trott](https://github.com/Trott) | [@Trott](https://twitter.com/Trott) | |

--- a/wontfix_cabal/participants.md
+++ b/wontfix_cabal/participants.md
@@ -27,3 +27,5 @@ sending a pull request!
 - Tim Smith (participant, [@tas50 on GitHub](https://github.com/tas50), [@tas50 on Twitter](https://twitter.com/tas50), PDX based
 - Brian Doll (participant, [@briandoll on GitHub](https://github.com/briandoll), [@briandoll on Twitter](https://twitter.com/briandoll), SF
 - Jaana Burcu Dogan (participant, [@rakyll on GitHub](https://github.com/rakyll), [@rakyll on Twitter](https://twitter.com/rakyll))
+- Rich Trott (participant, [@Trott on GitHub](https://github.com/Trott), [@Trott on Twitter](https://twitter.com/Trott))
+


### PR DESCRIPTION
Added myself as a participant. I also was finding the unordered list difficult to scan so I converted everything to a table. The table thing is in a separate commit and I (or you) can pull it out if you hate it.